### PR TITLE
Make cd command more shell compatible

### DIFF
--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -69,8 +69,7 @@ module Tacoma
       switch(environment)
       Dir.chdir `echo #{@repo}`.strip
       puts "Welcome to the tacoma shell"
-      shell = `echo $SHELL`
-      shell = shell.split('/').last.gsub(/\n/,'')
+      shell = ENV['SHELL'].split('/').last
       options =
         case shell
         when 'zsh'


### PR DESCRIPTION
Some love for the people who use zsh. Easily extensible for other shells.
