### PR TITLE
Prevent empty environment file creation

### DIFF
--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -21,7 +21,7 @@ module Tacoma
         config = Tool.config
         if config.keys.include?(environment) == false
           puts "Cannot find #{environment} key, check your YAML config file"
-          return
+          return false
         end
 
         if config[environment]
@@ -48,20 +48,20 @@ module Tacoma
     desc "switch ENVIRONMENT", "Loads AWS environment vars"
     def switch(environment)
 
-      Tool.load_vars(environment)
-      @aws_identity_file = Tool.aws_identity_file
-      @aws_secret_access_key = Tool.aws_secret_access_key
-      @aws_access_key_id = Tool.aws_access_key_id
-      @repo = Tool.repo
+      if Tool.load_vars(environment)
+        @aws_identity_file = Tool.aws_identity_file
+        @aws_secret_access_key = Tool.aws_secret_access_key
+        @aws_access_key_id = Tool.aws_access_key_id
+        @repo = Tool.repo
 
-      # set configurations for tools
-      {fog: '.fog', boto: '.boto', s3cfg: '.s3cfg', route53: '.route53'}.each do |tool, config_path|
-        template_path = Pathname.new("#{self.class.source_root}/../template/#{tool}").realpath.to_s
-        file_path = File.join(Dir.home, config_path)
-        template template_path, file_path, :force => true
+        # set configurations for tools
+        {fog: '.fog', boto: '.boto', s3cfg: '.s3cfg', route53: '.route53'}.each do |tool, config_path|
+          template_path = Pathname.new("#{self.class.source_root}/../template/#{tool}").realpath.to_s
+          file_path = File.join(Dir.home, config_path)
+          template template_path, file_path, :force => true
+        end
+        system("ssh-add #{@aws_identity_file}")
       end
-
-      system("ssh-add #{@aws_identity_file}")
     end
 
     desc "cd ENVIRONMENT", "Change directory to the project path"

--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -61,24 +61,28 @@ module Tacoma
           template template_path, file_path, :force => true
         end
         system("ssh-add #{@aws_identity_file}")
+        return true
+      else
+        return false
       end
     end
 
     desc "cd ENVIRONMENT", "Change directory to the project path"
     def cd(environment)
-      switch(environment)
-      Dir.chdir `echo #{@repo}`.strip
-      puts "Welcome to the tacoma shell"
-      shell = ENV['SHELL'].split('/').last
-      options =
-        case shell
-        when 'zsh'
-          ''
-        else
-          '--login'
-        end
-      system("#{shell} #{options}")
-      Process.kill(:SIGQUIT, Process.getpgid(Process.ppid))
+      if switch(environment)
+        Dir.chdir `echo #{@repo}`.strip
+        puts "Welcome to the tacoma shell"
+        shell = ENV['SHELL'].split('/').last
+        options =
+          case shell
+          when 'zsh'
+            ''
+          else
+            '--login'
+          end
+        system("#{shell} #{options}")
+        Process.kill(:SIGQUIT, Process.getpgid(Process.ppid))
+      end
     end
 
     desc "install", "Create a sample ~/.tacoma.yml file"


### PR DESCRIPTION
When asked to switch to an undefined environment tacoma warns about it but creates empty files from template

These commits prevent file creation and shell launching if there's no defined environmento to change into