### PR TITLE
Add region configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ The format of the `.tacoma.yml` file is pretty straighforward
        aws_identity_file: "/path/to/pem/file/my_project.pem"
        aws_secret_access_key: "YOURSECRETACCESSKEY"
        aws_access_key_id: "YOURACCESSKEYID"
+       region: "REGION"
        repo: "$HOME/projects/my_project"
 	 another_project:
        aws_identity_file: "/path/to/another_pem.pem"
        aws_secret_access_key: "ANOTHERECRETACCESSKEY"
        aws_access_key_id: "ANOTHERACCESSKEYID"
+       region: "REGION"
        repo: "$HOME/projects/another_project"
 
 Once setup with a file like this, you can run
@@ -49,7 +51,9 @@ Will display the current tacoma version and list all available configuration tem
 
      tacoma current
      
-Will display the currently active tacoma environment.  
+Will display the currently active tacoma environment.
+
+If you don't indicate a specific region, tacoma will use the "eu-west-1" region by default.
 
 ## Bash Completion
 

--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -8,12 +8,13 @@ module Tacoma
 
   
   module Tool
-
+    DEFAULT_AWS_REGION = 'eu-west-1'
 
     class << self
       attr_accessor :aws_identity_file
       attr_accessor :aws_secret_access_key
       attr_accessor :aws_access_key_id
+      attr_accessor :region
       attr_accessor :repo
 
       include CacheEnvironment 
@@ -30,6 +31,7 @@ module Tacoma
         @aws_identity_file = config[environment]['aws_identity_file']
         @aws_secret_access_key = config[environment]['aws_secret_access_key']
         @aws_access_key_id = config[environment]['aws_access_key_id']
+        @region = config[environment]['region'] || DEFAULT_AWS_REGION
         @repo = config[environment]['repo']
       end
       
@@ -94,6 +96,7 @@ module Tacoma
         @aws_identity_file = Tool.aws_identity_file
         @aws_secret_access_key = Tool.aws_secret_access_key
         @aws_access_key_id = Tool.aws_access_key_id
+        @region = Tool.region
         @repo = Tool.repo
 
 
@@ -111,6 +114,7 @@ module Tacoma
           puts "export AWS_SECRET_KEY=#{@aws_secret_access_key}"
           puts "export AWS_ACCESS_KEY=#{@aws_access_key_id}"
           puts "export AWS_ACCESS_KEY_ID=#{@aws_access_key_id}"
+          puts "export AWS_DEFAULT_REGION=#{@region}"
         end
         
         update_environment_to_cache(environment)

--- a/lib/template/aws_credentials
+++ b/lib/template/aws_credentials
@@ -3,3 +3,4 @@
 [default]
 aws_access_key_id = <%= @aws_access_key_id %>
 aws_secret_access_key = <%= @aws_secret_access_key %>
+region = <%= @region %>

--- a/lib/template/tacoma.yml
+++ b/lib/template/tacoma.yml
@@ -11,10 +11,12 @@ my_first_project:
   aws_identity_file: "/path/to/pem/file/my_project.pem"
   aws_secret_access_key: "YOURSECRETACCESSKEY"
   aws_access_key_id: "YOURACCESSKEYID"
+  region: 'REGION'  
   repo: "$HOME/projects/my_first_project"
 
 my_second_project:
   aws_identity_file: "/path/to/pem/file/my_second_project.pem"
   aws_secret_access_key: "ANOTHERSECRETACCESSKEY"
   aws_access_key_id: "ANOTHERACCESSKEYID"
+  region: 'REGION'
   repo: "/usr/share/projects/my_second_project"


### PR DESCRIPTION
Con este commit permitimos configurar también la **region** de AWS de cada proyecto, indicando en el fichero tacoma.yml la region en la que está la infraestructura.

Ejemplo:
```
 project:
   aws_secret_access_key: "YOURSECRETACCESSKEY"
   aws_access_key_id: "YOURACCESSKEYID"
   region: "us-east-1"
```