### PR TITLE
repo, region and identity file optional. secre_key and key_id mandatory

### DIFF
--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -33,6 +33,7 @@ module Tacoma
         @aws_access_key_id = config[environment]['aws_access_key_id']
         @region = config[environment]['region'] || DEFAULT_AWS_REGION
         @repo = config[environment]['repo']
+        return @aws_secret_access_key.length && @aws_access_key_id.length
       end
       
       # Assume there is a ~/.aws/credentials file with a valid format


### PR DESCRIPTION
If you have not defined the repo path in the `tacoma.yml` file, `tacoma switch project` fails without an output because [this line](https://github.com/pantulis/tacoma/blob/master/lib/tacoma/command.rb#L35) returns false.

This PR made `repo, region and identity_file` optionals and `access_key and secret_access_key`mandatory


cc/ @epergo