### PR TITLE
fix build_template_path and test

### DIFF
--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -162,10 +162,13 @@ module Tacoma
       File.dirname(__FILE__)
     end
 
-    private
-
-    def build_template_path(template_name)
-      "#{self.class.source_root}/../template/#{template_name}"
+    # private
+    no_commands do
+      def build_template_path(template_name)
+        Pathname.new(
+          "#{self.class.source_root}/../template/#{template_name}"
+        ).realpath.to_s
+      end
     end
   end
 end

--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -158,12 +158,14 @@ module Tacoma
       end
     end
 
-    def build_template_path(template_name)
-      "#{self.class.source_root}/../template/#{template_name}".realpath.to_s
-    end
-
     def self.source_root
       File.dirname(__FILE__)
+    end
+
+    private
+
+    def build_template_path(template_name)
+      "#{self.class.source_root}/../template/#{template_name}"
     end
   end
 end

--- a/spec/fixtures/.tacoma.yml
+++ b/spec/fixtures/.tacoma.yml
@@ -1,0 +1,18 @@
+project:
+  aws_identity_file: "/path/to/pem/file/my_project.pem"
+  aws_secret_access_key: "YOURSECRETACCESSKEY"
+  aws_access_key_id: "YOURACCESSKEYID"
+  region: "REGION"
+  repo: "$HOME/projects/my_project"
+another_project:
+  aws_identity_file: "/path/to/another_pem.pem"
+  aws_secret_access_key: "ANOTHERECRETACCESSKEY"
+  aws_access_key_id: "ANOTHERACCESSKEYID"
+  repo: "$HOME/projects/another_project"
+  s3cfg:
+    gpg_passphrase: my_gpg_passphrase
+error_project:
+  aws_identity_file: "/path/to/another_pem.pem"
+  repo: "$HOME/projects/another_project"
+  s3cfg:
+    gpg_passphrase: my_gpg_passphrase

--- a/spec/tacoma_spec.rb
+++ b/spec/tacoma_spec.rb
@@ -34,6 +34,14 @@ describe "Tacoma::Tool" do
     expect(subject).to eq(false)
   end
 
+  it "#build_template_path build a absolute path" do
+    allow(Tacoma::Tool).to receive(:config) { tacoma_config }
+    tacoma_command = Tacoma::Command.new
+    subject = tacoma_command.build_template_path("s3cfg")
+    expect(subject).to_not match(/\.\./)
+    expect(subject).to match(/template\/s3cfg/)
+  end
+
   it "#switch to another_project render tools templates" do
     tacoma_command = Tacoma::Command.new
     allow(Tacoma::Tool).to receive(:config) { tacoma_config }

--- a/spec/tacoma_spec.rb
+++ b/spec/tacoma_spec.rb
@@ -1,0 +1,54 @@
+require 'tacoma'
+require 'pry'
+
+describe "Tacoma::Tool" do
+
+  let(:tacoma_config) {
+    YAML.load_file("spec/fixtures/.tacoma.yml")
+  }
+
+  it "default values" do
+    expect(Tacoma::Tool::DEFAULT_AWS_REGION).to eq("eu-west-1")
+  end
+
+  it "#config" do
+    allow(Tacoma::Tool).to receive(:config) { tacoma_config }
+    expect(Tacoma::Tool.config).to eq(tacoma_config)
+  end
+
+  it "#load_vars" do
+    allow(Tacoma::Tool).to receive(:config) { tacoma_config }
+    Tacoma::Tool.load_vars("another_project")
+    expect(Tacoma::Tool.aws_identity_file).to eq("/path/to/another_pem.pem")
+    expect(Tacoma::Tool.aws_secret_access_key).to eq("ANOTHERECRETACCESSKEY")
+    expect(Tacoma::Tool.aws_access_key_id).to eq("ANOTHERACCESSKEYID")
+    expect(Tacoma::Tool.region).to eq(Tacoma::Tool::DEFAULT_AWS_REGION)
+    expect(Tacoma::Tool.repo).to eq("$HOME/projects/another_project")
+    expect(Tacoma::Tool.s3cfg).to eq({"gpg_passphrase" => "my_gpg_passphrase" })
+  end
+
+  it "#load_vars validate_vars fail" do
+    allow(Tacoma::Tool).to receive(:config) { tacoma_config }
+    expect(STDOUT).to receive(:puts).with("Cannot find @aws_secret_access_key key, check your YAML config file.\nCannot find @aws_access_key_id key, check your YAML config file.")
+    subject = Tacoma::Tool.load_vars("error_project")
+    expect(subject).to eq(false)
+  end
+
+  it "#switch to another_project render tools templates" do
+    tacoma_command = Tacoma::Command.new
+    allow(Tacoma::Tool).to receive(:config) { tacoma_config }
+    expect(tacoma_command).to receive(:template).at_least(5).times
+
+    response = tacoma_command.switch("another_project")
+
+    expect(tacoma_command.instance_variable_get("@aws_identity_file")).to be_a(String)
+    expect(tacoma_command.instance_variable_get("@aws_secret_access_key")).to be_a(String)
+    expect(tacoma_command.instance_variable_get("@aws_access_key_id")).to be_a(String)
+    expect(tacoma_command.instance_variable_get("@region")).to be_a(String)
+    expect(tacoma_command.instance_variable_get("@repo")).to be_a(String)
+    expect(tacoma_command.instance_variable_get("@s3cfg")).to be_a(Hash)
+
+    expect(response).to eq(true)
+  end
+
+end


### PR DESCRIPTION
Fix #18

Fix real_path it's not a string method use [realpath](https://ruby-doc.org/core-2.2.4/File.html#method-c-realpath) to returns the real (absolute) pathname of pathname in the actual filesystem not containing symlinks or useless dots.

Test using Rspec.

```
rspec
```