### PR TITLE
Export new environment variables for kops 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Will display the currently active tacoma environment.
 
 If you don't indicate a specific region, tacoma will use the "eu-west-1" region by default.
 
+## KOPS
+
+In order to be able to export kops environment variables, add the following to your .tacoma.yml file:
+```yml
+project:
+  kubernetes_cluster_name: "YOUR_K8S_CLUSTER_NAME"
+  kubernetes_state: "s3://YOUR_S3_BUCKET_STATE"
+```
+Currently this only prints the environments ready for scripting with --with-exports option
+
 ## Bash Completion
 
 There's an user contributed script for bash completion feature. To use it simply get from the `/contrib/` path and source it in your bash session (after rbenv gets sourced if it is there)

--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -16,7 +16,6 @@ module Tacoma
       attr_accessor :kubernetes_state
       attr_accessor :kubernetes_cluster_name
 
-
       include CacheEnvironment
 
       def config

--- a/lib/tacoma/command.rb
+++ b/lib/tacoma/command.rb
@@ -13,6 +13,9 @@ module Tacoma
       attr_accessor :region
       attr_accessor :repo
       attr_accessor :s3cfg
+      attr_accessor :kubernetes_state
+      attr_accessor :kubernetes_cluster_name
+
 
       include CacheEnvironment
 
@@ -31,6 +34,8 @@ module Tacoma
         @region = config[environment]['region'] || DEFAULT_AWS_REGION
         @repo = config[environment]['repo']
         @s3cfg = config[environment]['s3cfg'] || {}
+        @kubernetes_state = config[environment]['kubernetes_state']
+        @kubernetes_cluster_name = config[environment]['kubernetes_cluster_name'] 
         validate_vars
       end
 
@@ -119,6 +124,8 @@ module Tacoma
           puts "export AWS_ACCESS_KEY=#{@aws_access_key_id}"
           puts "export AWS_ACCESS_KEY_ID=#{@aws_access_key_id}"
           puts "export AWS_DEFAULT_REGION=#{@region}"
+          puts "export NAME=#{@kubernetes_cluster_name}"
+          puts "export KOPS_STATE_STORE=#{@kubernetes_state}"
         end
 
         update_environment_to_cache(environment)


### PR DESCRIPTION
When working with kops you can use environment variables (i.e. the s3 bucket for cluster state or the cluster name) in order to simplify your job.

This PR adds a couple of new variables ($NAME & $KOPS_STATE_STORE) for use with the "--with-exports" options while switching tacoma environments